### PR TITLE
feat: update WhatsApp to use new ShareUrl

### DIFF
--- a/src/providers/WhatsApp.vue
+++ b/src/providers/WhatsApp.vue
@@ -56,7 +56,7 @@ export default {
       // Variables
       const width = 640;
       const height = 480;
-      const share_url = `https://web.whatsapp.com/send?text=${encodeURIComponent(
+      const share_url = `https://wa.me?text=${encodeURIComponent(
         this.$props.page_url
       )}`;
 


### PR DESCRIPTION
As documented here: https://faq.whatsapp.com/iphone/how-to-link-to-whatsapp-from-a-different-app/?lang=en

Why? The current one is not working on mobile.